### PR TITLE
Fix get_lang_class parsing

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -23,7 +23,7 @@ def set_lang_class(name, cls):
 
 
 def get_lang_class(name):
-    lang = re.split('[^a-zA-Z0-9_]', name, 1)[0]
+    lang = re.split('_', name, 1)[0]
     if lang not in LANGUAGES:
         raise RuntimeError('Language not supported: %s' % lang)
     return LANGUAGES[lang]


### PR DESCRIPTION
We want the get_lang_class to return "en" for both "en" and "en_glove_cc_300_1m_vectors". Changed the split rule in util.py > get_lang_class to "_" so that this happens. See issue https://github.com/spacy-io/spaCy/issues/338 for details.
